### PR TITLE
allow toggling the fmt_on_save feature per session

### DIFF
--- a/autoload/shfmt.vim
+++ b/autoload/shfmt.vim
@@ -14,7 +14,7 @@ function! shfmt#shfmt(current_args, line1, line2) abort
 		" we've erased the user's work!
 		undo
 	endif
-	" Reset the cursor position if we moved 
+	" Reset the cursor position if we moved
 	if l:cursor_position != getcurpos()
 		call setpos('.', l:cursor_position)
 	endif

--- a/plugin/shfmt.vim
+++ b/plugin/shfmt.vim
@@ -34,16 +34,14 @@ function! s:ShfmtSwitches(...)
 	return join(s:shfmt_switches, "\n")
 endfunction
 
-command! -range=% -complete=custom,s:ShfmtSwitches -nargs=? Shfmt :call shfmt#shfmt(<q-args>, <line1>, <line2>)
+command! -bar -range=% -complete=custom,s:ShfmtSwitches -nargs=? Shfmt :call shfmt#shfmt(<q-args>, <line1>, <line2>)
 
 augroup shfmt
 	autocmd!
-	if get(g:, 'shfmt_fmt_on_save', 1)
-		" Use BufWritePre to filter the file before it's written since we're
-		" processing current buffer instead of the saved file. 
-		autocmd BufWritePre *.sh Shfmt
-		autocmd FileType sh autocmd BufWritePre <buffer> Shfmt
-	endif
+	" Use BufWritePre to filter the file before it's written since we're
+	" processing current buffer instead of the saved file.
+	autocmd BufWritePre *.sh if get(g:, 'shfmt_fmt_on_save', 1) | Shfmt | endif
+	autocmd FileType sh autocmd BufWritePre <buffer> if get(g:, 'shfmt_fmt_on_save', 1) | Shfmt | endif
 augroup END
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Evaluate the **g:shfmt_fmt_on_save** variable when the autocmd is triggered.

To disable auto-save in the current session run:

```vim
:let g:shfmt_fmt_on_save = 0
```

To enable auto-save in the current session run:

```vim
:let g:shfmt_fmt_on_save = 1
```